### PR TITLE
ConfigurationSectionDesignerSchema template fix and logic change for finding TextTemplates folder

### DIFF
--- a/src/DslPackage.VS2017/CustomCode/CodeGeneration/FileGeneration.cs
+++ b/src/DslPackage.VS2017/CustomCode/CodeGeneration/FileGeneration.cs
@@ -301,33 +301,8 @@ namespace ConfigurationSectionDesigner
 
                 if (_textTemplateFolder == null)
                 {
-                    Diagnostics.DebugWrite("FileGeneration.TextTemplateFolder_get >> NULL... Loading from Registry...");
-
-                    //#if DEBUG
-                    // Fetch the install location from the registry
-                    string key = string.Format("{0}\\ExtensionManager\\EnabledExtensions",
-                            this.Project.DTE.RegistryRoot);
-                    RegistryKey csd = Registry.CurrentUser.OpenSubKey(key);
-                    if (csd != null)
-                    {
-                        string kn = string.Format("{0},{1}",
-                                          Constants.ConfigurationSectionDesignerPackageId,
-                                          Assembly.GetExecutingAssembly().GetName().Version.ToString()
-                                      );
-                        string extensionRootDir = csd.GetValue(kn) as string;
-                        if (!string.IsNullOrEmpty(extensionRootDir))
-                        {
-                            _textTemplateFolder = Path.Combine(extensionRootDir, "TextTemplates");
-                        }
-                        else
-                        {
-                            Diagnostics.DebugWrite("FileGeneration.TextTemplateFolder_get >> ERROR >> Result is NULL! RegKeyName={0}, RegKeyValue={1}", kn, "NULL");
-                            throw new InvalidOperationException("Could not find TextTemplate directory. Try reinstalling the Configuration Section Designer.");
-                        }
-                    }
-                    else
-                        throw new InvalidOperationException("Could not find TextTemplate directory. Try reinstalling the Configuration Section Designer.");
-                    //#endif
+                     Diagnostics.DebugWrite("Loading _textTemplateFolder from executable path");
+                    _textTemplateFolder = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TextTemplates");
                 }
                 return _textTemplateFolder;
             }

--- a/src/DslPackage.VS2017/TextTemplates/ConfigurationSectionDesignerSchema.tt
+++ b/src/DslPackage.VS2017/TextTemplates/ConfigurationSectionDesignerSchema.tt
@@ -199,7 +199,7 @@ foreach (BaseConfigurationType type in this.ConfigurationSectionModel.Configurat
 			string[] xsdRestrictions = null;
 			string xsdTypeName = "";
 
-			ConfigurationProperty keyProperty = itemType.KeyProperties.SingleOrDefault();
+			ConfigurationProperty keyProperty = collectionElement.ItemType.KeyProperties.SingleOrDefault();
 			if (keyProperty != null) {
 				xsdTypeName = GetXsdTypeName(keyProperty as AttributeProperty, out xsdRestrictions);
 				if (!string.IsNullOrEmpty(xsdTypeName))
@@ -245,7 +245,7 @@ foreach (BaseConfigurationType type in this.ConfigurationSectionModel.Configurat
 		}
 	}
 	
-} // End loop over all configuration elements.
+ // End loop over all configuration elements.
 
 foreach (TypeDefinition type in this.ConfigurationSectionModel.TypeDefinitions)
 {


### PR DESCRIPTION
- Clean up an extra closing brace in the ConfigurationSectionDesignerSchema.tt template
- Fixed a variable error in ConfigurationSectionDesignerSchema.tt
- Changed the logic for finding TextTemplates directory in FIleGeneration.cs.  This relied on a registry entry before but that registry value is not populated on my system so generation consistently failed.  I think we should be save to get the TextTemplates folder relative to the executing assembly instead.  This works consistently for me now.