### PR TITLE
Visual Studio 2019 compatibility (No more than a nudge)

### DIFF
--- a/src/DslPackage.VS2017/source.extension.tt
+++ b/src/DslPackage.VS2017/source.extension.tt
@@ -31,8 +31,8 @@
 	<MoreInfoUrl>http://csd.codeplex.com/documentation</MoreInfoUrl>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0,16.0)" />
-    <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0,17.0)" />
+    <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6.1,)" />
@@ -47,6 +47,6 @@
     
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.TextTemplating" Version="[15.0,16.0)" DisplayName="Text Template Transformation" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.TextTemplating" Version="[15.0,17.0)" DisplayName="Text Template Transformation" />
   </Prerequisites>
 </PackageManifest>

--- a/src/DslPackage.VS2017/source.extension.vsixmanifest
+++ b/src/DslPackage.VS2017/source.extension.vsixmanifest
@@ -9,8 +9,8 @@
 	<MoreInfoUrl>http://csd.codeplex.com/documentation</MoreInfoUrl>
   </Metadata>
   <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0,16.0)" />
-    <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[15.0,17.0)" />
+    <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6.1,)" />
@@ -25,6 +25,6 @@
     
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.TextTemplating" Version="[15.0,16.0)" DisplayName="Text Template Transformation" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.TextTemplating" Version="[15.0,17.0)" DisplayName="Text Template Transformation" />
   </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
This is feeble start, compiling and installing now succeeds, but the extension fails to load with the following error message:

```
LegacySitePackage failed for package [ConfigurationSectionDesignerPackage]Source: 'mscorlib' Description: Could not load file or assembly 'Microsoft.VisualStudio.TextTemplating.VSHost.15.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.
System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.VisualStudio.TextTemplating.VSHost.15.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.
File name: 'Microsoft.VisualStudio.TextTemplating.VSHost.15.0, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
   at System.ModuleHandle.ResolveType(RuntimeModule module, Int32 typeToken, IntPtr* typeInstArgs, Int32 typeInstCount, IntPtr* methodInstArgs, Int32 methodInstCount, ObjectHandleOnStack type)
   at System.ModuleHandle.ResolveTypeHandleInternal(RuntimeModule module, Int32 typeToken, RuntimeTypeHandle[] typeInstantiationContext, RuntimeTypeHandle[] methodInstantiationContext)
   at System.Reflection.RuntimeModule.ResolveType(Int32 metadataToken, Type[] genericTypeArguments, Type[] genericMethodArguments)
   at System.Reflection.CustomAttribute.FilterCustomAttributeRecord(CustomAttributeRecord caRecord, MetadataImport scope, Assembly& lastAptcaOkAssembly, RuntimeModule decoratedModule, MetadataToken decoratedToken, RuntimeType attributeFilterType, Boolean mustBeInheritable, Object[] attributes, IList derivedAttributes, RuntimeType& attributeType, IRuntimeMethodInfo& ctor, Boolean& ctorHasParameters, Boolean& isVarArg)
   at System.Reflection.CustomAttribute.GetCustomAttributes(RuntimeModule decoratedModule, Int32 decoratedMetadataToken, Int32 pcaCount, RuntimeType attributeFilterType, Boolean mustBeInheritable, IList derivedAttributes, Boolean isDecoratedTargetSecurityTransparent)
   at System.Reflection.CustomAttribute.GetCustomAttributes(RuntimeType type, RuntimeType caType, Boolean inherit)
   at System.RuntimeType.GetCustomAttributes(Type attributeType, Boolean inherit)
   at Microsoft.VisualStudio.Shell.Package.ScheduleToolboxItemDiscoveryFactoriesRegistrationIfNecessary()
   at Microsoft.VisualStudio.Shell.Package.Initialize()
   at Microsoft.VisualStudio.Modeling.Shell.ModelingPackage.Initialize()
   at ConfigurationSectionDesigner.ConfigurationSectionDesignerPackageBase.Initialize()
   at Microsoft.VisualStudio.Shell.Package.Microsoft.VisualStudio.Shell.Interop.IVsPackage.SetSite(IServiceProvider sp)

WRN: Assembly binding logging is turned OFF.
To enable assembly bind failure logging, set the registry value [HKLM\Software\Microsoft\Fusion!EnableLog] (DWORD) to 1.
Note: There is some performance penalty associated with assembly bind failure logging.
To turn this feature off, remove the registry value [HKLM\Software\Microsoft\Fusion!EnableLog].
```